### PR TITLE
feat: add support for replica shards on master connection 

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -151,7 +151,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
       end
 
       def should_use_normal_connection?
-        if !Octopus.enabled? || must_use_normal_connection
+        if !Octopus.enabled? || must_use_normal_connection && !connection_proxy.current_shard.to_s.ends_with?('_replica')
           true
         elsif custom_octopus_connection
           !connection_proxy.block || !allowed_shard?(connection_proxy.current_shard)


### PR DESCRIPTION
This adds support to bypass the must_use_normal_connection flag
in order to use replicas