### PR TITLE
fix: ocotpus using association shard rather than the current shard

### DIFF
--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -30,8 +30,6 @@ module Octopus
         if !record.current_shard.nil? && !current_shard.nil? && record.current_shard.to_s != current_shard.to_s
           raise MismatchedShards.new(record, current_shard)
         end
-
-        record.current_shard = self.class.connection.current_shard = current_shard if should_set_current_shard?
       end
     end
 


### PR DESCRIPTION
Octopus tries to use the shard that the associated record came from if
it was using a shard (not the master connection).

This was causing problems because we manually specify shards, but
octopus was trying to override that logic.