### PR TITLE
fix: octopus using association shard rather than the current shard for master db

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -40,7 +40,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
       def set_current_shard
         return unless Octopus.enabled?
         shard = self.class.connection_proxy.current_shard
-        self.current_shard = shard if self.class.allowed_shard?(shard)
+        self.current_shard = shard if self.class.allowed_shard?(shard) && !self.must_use_normal_connection
       end
 
       def init_with(coder)

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -66,7 +66,7 @@ If you are trying to scope everything to a specific shard, use Octopus.using ins
       end
 
       def should_set_current_shard?
-        self.respond_to?(:current_shard) && !current_shard.nil?
+        self.respond_to?(:current_shard) && !current_shard.nil? && !must_use_normal_connection
       end
 
       def equality_with_octopus(comparison_object)


### PR DESCRIPTION
Octopus tries to use the shard that the associated record came from if
it was using a shard (not the master connection).

This was causing problems because we manually specify shards, but
octopus was trying to override that logic.